### PR TITLE
Updated Main Field of Package.json 

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-css-transition-replace",
   "version": "1.1.0",
   "description": "A React component to animate replacing one element with another.",
-  "main": "lib/CSSTransitionReplace.js",
+  "main": "lib/ReactCSSTransitionReplace.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/marnusw/react-css-transition-replace.git"


### PR DESCRIPTION
I was having issues with my Meteor 1.3 app because the main field inside the Package.json didn't refer to  a file that actually existed. This was fine in the past because most apps just take the root index.js file and is not strict about what's inside the main field of the Package.json. For better or worse, Meteor 1.3 is more strict with this.

This PR fixes that issue.