### PR TITLE
Update for React 15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### v1.2.0-beta (18 April 2016)
+
+* [UPGRADE] Add peer dependency `react@15.0.1`.
+  *Note: When adding/removing content completely in rapid successions strange things happen with this change. 
+  (Thus beta status)*
+* [ENHANCEMENT] Add a `displayName` field.
+
 ### v1.1.2 (9 April 2016)
 
 * [UPGRADE] Use the `object-assign` lib, as [React 15 does](https://github.com/facebook/react/pull/6376), rather

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-css-transition-replace",
-  "version": "1.1.2",
+  "version": "1.2.0-beta",
   "description": "A React component to animate replacing one element with another.",
   "main": "lib/ReactCSSTransitionReplace.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -15,32 +15,32 @@
   },
   "dependencies": {
     "object-assign": "^4.0.1",
-    "react-addons-css-transition-group": "^0.14.0"
+    "react-addons-css-transition-group": "^15.0.1"
   },
   "peerDependencies": {
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0"
+    "react": "^0.14.0 || ^15.0.0",
+    "react-dom": "^0.14.0 || ^15.0.0"
   },
   "devDependencies": {
-    "babel": "^5.8.23",
-    "babel-eslint": "^4.1.3",
-    "babelify": "^6.3.0",
-    "browser-sync": "^2.9.11",
+    "babel": "^5.8.38",
+    "babel-eslint": "^4.1.8",
+    "babelify": "^6.4.0",
+    "browser-sync": "^2.12.3",
     "browserify": "^11.2.0",
-    "del": "^2.0.2",
-    "eslint": "^1.6.0",
-    "eslint-plugin-react": "^3.5.1",
+    "del": "^2.2.0",
+    "eslint": "^1.10.3",
+    "eslint-plugin-react": "^3.16.1",
     "gulp": "^3.9.1",
-    "gulp-eslint": "^1.0.0",
+    "gulp-eslint": "^1.1.1",
     "gulp-flatten": "^0.2.0",
     "gulp-notify": "^2.2.0",
     "lodash.assign": "^3.2.0",
-    "react": "^0.14.0",
-    "react-bootstrap": "^0.27.1",
-    "react-dom": "^0.14.0",
+    "react": "^15.0.0",
+    "react-bootstrap": "^0.27.3",
+    "react-dom": "^15.0.0",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
-    "watchify": "^3.4.0"
+    "watchify": "^3.7.0"
   },
   "author": "Marnus Weststrate <marnusw@gmail.com>",
   "contributors": [],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-css-transition-replace",
-  "version": "1.2.0-beta",
+  "version": "1.2.1",
   "description": "A React component to animate replacing one element with another.",
   "main": "lib/ReactCSSTransitionReplace.js",
   "repository": {
@@ -14,30 +14,30 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "object-assign": "^4.0.1",
-    "react-addons-css-transition-group": "^15.0.1"
+    "object-assign": "^4.1.0",
+    "react-addons-css-transition-group": "^15.2.0"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0"
+    "react": "^15.2.0",
+    "react-dom": "^15.2.0"
   },
   "devDependencies": {
     "babel": "^5.8.38",
     "babel-eslint": "^4.1.8",
     "babelify": "^6.4.0",
-    "browser-sync": "^2.12.3",
+    "browser-sync": "^2.13.0",
     "browserify": "^11.2.0",
-    "del": "^2.2.0",
+    "del": "^2.2.1",
     "eslint": "^1.10.3",
-    "eslint-plugin-react": "^3.16.1",
+    "eslint-plugin-react": "^3.5.1",
     "gulp": "^3.9.1",
     "gulp-eslint": "^1.1.1",
     "gulp-flatten": "^0.2.0",
     "gulp-notify": "^2.2.0",
     "lodash.assign": "^3.2.0",
-    "react": "^15.0.0",
-    "react-bootstrap": "^0.27.3",
-    "react-dom": "^15.0.0",
+    "react": "^15.2.0",
+    "react-bootstrap": "^0.29.5",
+    "react-dom": "^15.2.0",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.7.0"

--- a/src/ReactCSSTransitionReplace.jsx
+++ b/src/ReactCSSTransitionReplace.jsx
@@ -40,6 +40,8 @@ function createTransitionTimeoutPropValidator(transitionType) {
 
 export default class ReactCSSTransitionReplace extends React.Component {
 
+  static displayName = 'ReactCSSTransitionReplace';
+
   static propTypes = {
     transitionName: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.shape({
       enter: React.PropTypes.string,
@@ -166,7 +168,7 @@ export default class ReactCSSTransitionReplace extends React.Component {
 
       this.setState(state);
     }
-  };
+  }
 
   _wrapChild(child, moreProps) {
     // We need to provide this childFactory so that

--- a/src/ReactCSSTransitionReplace.jsx
+++ b/src/ReactCSSTransitionReplace.jsx
@@ -189,7 +189,17 @@ export default class ReactCSSTransitionReplace extends React.Component {
     const { currentChild, nextChild, height } = this.state;
     const childrenToRender = [];
 
-    const { overflowHidden, ...containerProps } = this.props;
+    const {
+      overflowHidden,
+      transitionName,
+      transitionEnterTimeout,
+      transitionLeaveTimeout,
+      transitionAppear,
+      transitionEnter,
+      transitionLeave,
+      component,
+      ...containerProps
+    } = this.props;
 
     if (currentChild) {
       childrenToRender.push(this._wrapChild(currentChild, {


### PR DESCRIPTION
- Removed passing properties while deconstructing props that are not compatible with standard dom elements such as a span.
- Updated packages to latest versions.