### PR TITLE
+ option for child component wrapper

### DIFF
--- a/src/ReactCSSTransitionReplace.jsx
+++ b/src/ReactCSSTransitionReplace.jsx
@@ -71,6 +71,7 @@ export default class ReactCSSTransitionReplace extends React.Component {
     transitionLeave: true,
     overflowHidden: true,
     component: 'span',
+    childComponent: 'span',
   }
 
   state = {
@@ -233,7 +234,7 @@ export default class ReactCSSTransitionReplace extends React.Component {
     const childrenToRender = []
 
     const {
-      overflowHidden, transitionName, component,
+      overflowHidden, transitionName, component, childComponent,
       transitionAppear, transitionEnter, transitionLeave,
       transitionAppearTimeout, transitionEnterTimeout, transitionLeaveTimeout,
       ...containerProps
@@ -259,7 +260,7 @@ export default class ReactCSSTransitionReplace extends React.Component {
 
     Object.keys(prevChildren).forEach(key => {
       childrenToRender.push(
-        React.createElement('span',
+        React.createElement(childComponent,
           {
             key,
             style: {
@@ -281,7 +282,7 @@ export default class ReactCSSTransitionReplace extends React.Component {
 
     if (currentChild) {
       childrenToRender.push(
-        React.createElement('span',
+        React.createElement(childComponent,
           {key: currentKey},
           this.wrapChild(currentChild, {ref: currentKey})
         )


### PR DESCRIPTION
Hi, adding the capability to specify wrapper for child components which are spans right now.  Those spans are breaking ability to switch between descendants of ReactCSSTransitionReplace with the tab inside of ReactModal component (it [decides](https://github.com/reactjs/react-modal/blob/master/lib/helpers/tabbable.js) whether component is "tabbable" depending on `offsetHeight` of component's ancestors).
#36 