### PR TITLE
use react-transition-group package

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "react-addons-css-transition-group": "^15.0.0"
+    "react-transition-group": "^1.1.1"
   },
   "peerDependencies": {
     "react": "^15.0.0",

--- a/src/ReactCSSTransitionReplace.jsx
+++ b/src/ReactCSSTransitionReplace.jsx
@@ -7,7 +7,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 
-import ReactCSSTransitionGroupChild from 'react/lib/ReactCSSTransitionGroupChild'
+import ReactCSSTransitionGroupChild from 'react-transition-group/CSSTransitionGroupChild'
 
 const reactCSSTransitionGroupChild = React.createFactory(ReactCSSTransitionGroupChild)
 


### PR DESCRIPTION
This PR swaps out the dependency on `react-addons-css-transition-group` for [`react-transition-group`][1].  As of React v15.5.0, support for `react-addons-css-transition-group` is discontinued, with `react-transition-group` being offered as a drop-in replacement that may be more actively maintained in the future.

I tested this PR by installing it in my React v15.5.0 app which uses ReactCSSTransitionReplace.

See the https://github.com/facebook/react/issues/8125 and the [React v15.5 blog post][2] for more context: 

> react-addons-css-transition-group - Use [react-transition-group/CSSTransitionGroup][1] instead. Version 1.1.1 provides a drop-in replacement.

[1]: https://github.com/reactjs/react-transition-group
[2]: https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#discontinuing-support-for-react-addons