### PR TITLE
Fix missing caret in peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "peerDependencies": {
     "react": "^15.0.0 || ^16.0.0",
-    "react-dom": "15.0.0 || ^16.0.0"
+    "react-dom": "^15.0.0 || ^16.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",


### PR DESCRIPTION
This is causing a warning in `npm install` and an error in `npm shrinkwrap`.