### PR TITLE
Prefix unsafe lifecycle methods with `UNSAFE_`

### DIFF
--- a/packages/react-css-transition-replace/src/ReactCSSTransitionReplace.js
+++ b/packages/react-css-transition-replace/src/ReactCSSTransitionReplace.js
@@ -62,7 +62,7 @@ export default class ReactCSSTransitionReplace extends React.Component {
     }
   }
 
-  componentWillUnmount() {
+  UNSAFE_componentWillUnmount() {
     this.unmounted = true
   }
 

--- a/packages/react-css-transition-replace/src/ReactCSSTransitionReplaceChild.js
+++ b/packages/react-css-transition-replace/src/ReactCSSTransitionReplaceChild.js
@@ -61,7 +61,7 @@ class CSSTransitionGroupChild extends React.Component {
     this.transitionTimeouts = []
   }
 
-  componentWillUnmount() {
+  UNSAFE_componentWillUnmount() {
     this.unmounted = true
 
     if (this.timeout) {


### PR DESCRIPTION
Fixes https://github.com/marnusw/react-css-transition-replace/issues/63