### PR TITLE
Replace deprecated React.createFactory call

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ that the transition duration must be specified in JavaScript as well as CSS.
 [Change Log](/CHANGELOG.md) |
 [Upgrade Guide](/UPGRADE_GUIDE.md)
 
+<div align="center">
+  <i>ReactCSSTransitionReplace is sponsored by the following partner, please help to support us by taking a look.</i>
+  <a href="https://tracking.gitads.io/?repo=react-css-transition-replace">
+    <img src="https://images.gitads.io/react-css-transition-replace" alt="" />
+  </a>
+</div>
+
 ## Installation
 
 Install via `npm`:

--- a/packages/react-css-transition-replace/src/ReactCSSTransitionReplace.js
+++ b/packages/react-css-transition-replace/src/ReactCSSTransitionReplace.js
@@ -7,7 +7,10 @@ import raf from 'dom-helpers/util/requestAnimationFrame'
 import ReactCSSTransitionReplaceChild from './ReactCSSTransitionReplaceChild'
 import { nameShape, transitionTimeout } from './utils/PropTypes'
 
-const reactCSSTransitionReplaceChild = React.createFactory(ReactCSSTransitionReplaceChild)
+const reactCSSTransitionReplaceChild = React.createElement.bind(
+  null,
+  ReactCSSTransitionReplaceChild,
+)
 
 export default class ReactCSSTransitionReplace extends React.Component {
   static displayName = 'ReactCSSTransitionReplace'


### PR DESCRIPTION
Fixes #70 

Refactored using the code suggestion on https://reactjs.org/blog/2020/02/26/react-v16.13.0.html#deprecating-reactcreatefactory