### PR TITLE
Remove find dom node

### DIFF
--- a/packages/demo/src/components/ContentLong.js
+++ b/packages/demo/src/components/ContentLong.js
@@ -1,8 +1,9 @@
 import React from 'react'
 
-function ContentLong({ className }) {
+const ContentLong = React.forwardRef((props, ref) => {
+  const { className } = props
   return (
-    <div className={className}>
+    <div className={className} ref={ref}>
       <b>Some longer content</b>
       <p>
         Suspendisse non ante dui. Phasellus tempor sem non cursus feugiat. Pellentesque quis justo
@@ -16,6 +17,6 @@ function ContentLong({ className }) {
       </p>
     </div>
   )
-}
+})
 
 export default ContentLong

--- a/packages/demo/src/components/ContentLong.js
+++ b/packages/demo/src/components/ContentLong.js
@@ -1,9 +1,8 @@
 import React from 'react'
 
-const ContentLong = React.forwardRef((props, ref) => {
-  const { className } = props
+function ContentLong({ className }) {
   return (
-    <div className={className} ref={ref}>
+    <div className={className}>
       <b>Some longer content</b>
       <p>
         Suspendisse non ante dui. Phasellus tempor sem non cursus feugiat. Pellentesque quis justo
@@ -17,6 +16,6 @@ const ContentLong = React.forwardRef((props, ref) => {
       </p>
     </div>
   )
-})
+}
 
 export default ContentLong

--- a/packages/demo/src/components/ContentShort.js
+++ b/packages/demo/src/components/ContentShort.js
@@ -1,8 +1,9 @@
 import React from 'react'
 
-function ContentShort({ className }) {
+const ContentShort = React.forwardRef((props, ref) => {
+  const { className } = props
   return (
-    <div className={className}>
+    <div className={className} ref={ref}>
       <b>Some shorter content</b>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce pulvinar pharetra magna ac
@@ -12,6 +13,6 @@ function ContentShort({ className }) {
       </p>
     </div>
   )
-}
+})
 
 export default ContentShort

--- a/packages/demo/src/components/ContentShort.js
+++ b/packages/demo/src/components/ContentShort.js
@@ -1,9 +1,8 @@
 import React from 'react'
 
-const ContentShort = React.forwardRef((props, ref) => {
-  const { className } = props
+function ContentShort({ className }) {
   return (
-    <div className={className} ref={ref}>
+    <div className={className}>
       <b>Some shorter content</b>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce pulvinar pharetra magna ac
@@ -13,6 +12,6 @@ const ContentShort = React.forwardRef((props, ref) => {
       </p>
     </div>
   )
-})
+}
 
 export default ContentShort

--- a/packages/react-css-transition-replace/src/ReactCSSTransitionReplace.js
+++ b/packages/react-css-transition-replace/src/ReactCSSTransitionReplace.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { findDOMNode } from 'react-dom'
 import PropTypes from 'prop-types'
 
 import { request as raf } from 'dom-helpers/animationFrame'
@@ -87,7 +88,7 @@ export default class ReactCSSTransitionReplace extends React.Component {
     }
 
     if (currentChild) {
-      const currentChildNode = this.childRefs[currentKey].current?.getNode()
+      const currentChildNode = findDOMNode(this.childRefs[currentKey])
       nextState.height = currentChildNode ? currentChildNode.offsetHeight : 0
       nextState.width = this.props.changeWidth
         ? currentChildNode
@@ -110,7 +111,7 @@ export default class ReactCSSTransitionReplace extends React.Component {
     if (this.shouldEnterCurrent) {
       this.shouldEnterCurrent = false
       // If the current child renders null there is nothing to enter
-      if (this.childRefs[this.state.currentKey].current?.getNode()) {
+      if (findDOMNode(this.childRefs[this.state.currentKey])) {
         this.performEnter(this.state.currentKey)
       }
     }
@@ -122,7 +123,7 @@ export default class ReactCSSTransitionReplace extends React.Component {
 
   performAppear(key) {
     this.transitioningKeys[key] = true
-    this.childRefs[key].current?.componentWillAppear(this.handleDoneAppearing.bind(this, key))
+    this.childRefs[key].componentWillAppear(this.handleDoneAppearing.bind(this, key))
   }
 
   handleDoneAppearing = (key) => {
@@ -135,7 +136,7 @@ export default class ReactCSSTransitionReplace extends React.Component {
 
   performEnter(key) {
     this.transitioningKeys[key] = true
-    this.childRefs[key].current?.componentWillEnter(this.handleDoneEntering.bind(this, key))
+    this.childRefs[key].componentWillEnter(this.handleDoneEntering.bind(this, key))
     this.enqueueHeightTransition()
   }
 
@@ -152,8 +153,8 @@ export default class ReactCSSTransitionReplace extends React.Component {
 
   performLeave = (key) => {
     this.transitioningKeys[key] = true
-    this.childRefs[key].current?.componentWillLeave(this.handleDoneLeaving.bind(this, key))
-    if (!this.state.currentChild || !this.childRefs[this.state.currentKey].current?.getNode()) {
+    this.childRefs[key].componentWillLeave(this.handleDoneLeaving.bind(this, key))
+    if (!this.state.currentChild || !findDOMNode(this.childRefs[this.state.currentKey])) {
       // The enter transition dominates, but if there is no entering
       // component or it renders null the height is set to zero.
       this.enqueueHeightTransition()
@@ -167,7 +168,7 @@ export default class ReactCSSTransitionReplace extends React.Component {
     delete nextState.prevChildren[key]
     delete this.childRefs[key]
 
-    if (!this.state.currentChild || !this.childRefs[this.state.currentKey].current?.getNode()) {
+    if (!this.state.currentChild || !findDOMNode(this.childRefs[this.state.currentKey])) {
       nextState.height = null
     }
 
@@ -184,7 +185,7 @@ export default class ReactCSSTransitionReplace extends React.Component {
     if (!this.unmounted) {
       const { state } = this
       const currentChildNode = state.currentChild
-        ? this.childRefs[state.currentKey].current?.getNode()
+        ? findDOMNode(this.childRefs[state.currentKey])
         : null
       this.setState({
         height: currentChildNode ? currentChildNode.offsetHeight : 0,
@@ -220,16 +221,6 @@ export default class ReactCSSTransitionReplace extends React.Component {
       },
       child,
     )
-  }
-
-  setChildRef = (id, node) => {
-    if (node) {
-      const ref = React.createRef()
-      ref.current = node
-      this.childRefs[id] = ref
-    } else {
-      delete this.childRefs[id]
-    }
   }
 
   render() {
@@ -303,7 +294,7 @@ export default class ReactCSSTransitionReplace extends React.Component {
             notifyLeaving && typeof child.type !== 'string'
               ? React.cloneElement(child, { isLeaving: true })
               : child,
-            { ref: (r) => this.setChildRef(key, r) },
+            { ref: (r) => (this.childRefs[key] = r) },
           ),
         ),
       )
@@ -323,7 +314,7 @@ export default class ReactCSSTransitionReplace extends React.Component {
               ? { position: 'relative' }
               : null,
           },
-          this.wrapChild(currentChild, { ref: (r) => this.setChildRef(currentKey, r) }),
+          this.wrapChild(currentChild, { ref: (r) => (this.childRefs[currentKey] = r) }),
         ),
       )
     }

--- a/packages/react-css-transition-replace/src/ReactCSSTransitionReplaceChild.js
+++ b/packages/react-css-transition-replace/src/ReactCSSTransitionReplaceChild.js
@@ -10,7 +10,6 @@ import transitionEnd from 'dom-helpers/transitionEnd'
 import { request as raf } from 'dom-helpers/animationFrame'
 import React from 'react'
 import PropTypes from 'prop-types'
-import { findDOMNode } from 'react-dom'
 
 import { nameShape } from './utils/PropTypes'
 
@@ -51,6 +50,7 @@ const propTypes = {
 
 class CSSTransitionGroupChild extends React.Component {
   static displayName = 'CSSTransitionGroupChild'
+  refNode = React.createRef()
 
   constructor(props) {
     super(props)
@@ -71,8 +71,12 @@ class CSSTransitionGroupChild extends React.Component {
     this.classNameAndNodeQueue.length = 0
   }
 
+  getNode() {
+    return this.refNode.current
+  }
+
   transition(animationType, finishCallback, timeout) {
-    const node = findDOMNode(this)
+    const node = this.getNode()
 
     if (!node) {
       if (finishCallback) {
@@ -181,7 +185,7 @@ class CSSTransitionGroupChild extends React.Component {
   }
 
   render() {
-    const props = { ...this.props }
+    const props = { ...this.props, ref: this.refNode }
     delete props.name
     delete props.appear
     delete props.enter

--- a/packages/react-css-transition-replace/src/ReactCSSTransitionReplaceChild.js
+++ b/packages/react-css-transition-replace/src/ReactCSSTransitionReplaceChild.js
@@ -10,6 +10,7 @@ import transitionEnd from 'dom-helpers/transitionEnd'
 import { request as raf } from 'dom-helpers/animationFrame'
 import React from 'react'
 import PropTypes from 'prop-types'
+import { findDOMNode } from 'react-dom'
 
 import { nameShape } from './utils/PropTypes'
 
@@ -50,7 +51,6 @@ const propTypes = {
 
 class CSSTransitionGroupChild extends React.Component {
   static displayName = 'CSSTransitionGroupChild'
-  refNode = React.createRef()
 
   constructor(props) {
     super(props)
@@ -71,12 +71,8 @@ class CSSTransitionGroupChild extends React.Component {
     this.classNameAndNodeQueue.length = 0
   }
 
-  getNode() {
-    return this.refNode.current
-  }
-
   transition(animationType, finishCallback, timeout) {
-    const node = this.getNode()
+    const node = findDOMNode(this)
 
     if (!node) {
       if (finishCallback) {
@@ -185,7 +181,7 @@ class CSSTransitionGroupChild extends React.Component {
   }
 
   render() {
-    const props = { ...this.props, ref: this.refNode }
+    const props = { ...this.props }
     delete props.name
     delete props.appear
     delete props.enter


### PR DESCRIPTION
Similar to https://github.com/reactjs/react-transition-group/releases/tag/v4.4.0

This has a breaking change for functional components as they will need to use forwardRef 