### PR TITLE
Remove deprecated findDOMNode

### DIFF
--- a/packages/demo/src/components/ContentLong.js
+++ b/packages/demo/src/components/ContentLong.js
@@ -1,8 +1,9 @@
 import React from 'react'
 
-function ContentLong({ className }) {
+const ContentLong = React.forwardRef((props, ref) => {
+  const { className } = props
   return (
-    <div className={className}>
+    <div className={className} ref={ref}>
       <b>Some longer content</b>
       <p>
         Suspendisse non ante dui. Phasellus tempor sem non cursus feugiat. Pellentesque quis justo
@@ -16,6 +17,6 @@ function ContentLong({ className }) {
       </p>
     </div>
   )
-}
+})
 
 export default ContentLong

--- a/packages/demo/src/components/ContentShort.js
+++ b/packages/demo/src/components/ContentShort.js
@@ -1,8 +1,9 @@
 import React from 'react'
 
-function ContentShort({ className }) {
+const ContentShort = React.forwardRef((props, ref) => {
+  const { className } = props
   return (
-    <div className={className}>
+    <div className={className} ref={ref}>
       <b>Some shorter content</b>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce pulvinar pharetra magna ac
@@ -12,6 +13,6 @@ function ContentShort({ className }) {
       </p>
     </div>
   )
-}
+})
 
 export default ContentShort

--- a/packages/react-css-transition-replace/src/ReactCSSTransitionReplaceChild.js
+++ b/packages/react-css-transition-replace/src/ReactCSSTransitionReplaceChild.js
@@ -10,7 +10,6 @@ import transitionEnd from 'dom-helpers/transitionEnd'
 import { request as raf } from 'dom-helpers/animationFrame'
 import React from 'react'
 import PropTypes from 'prop-types'
-import { findDOMNode } from 'react-dom'
 
 import { nameShape } from './utils/PropTypes'
 
@@ -51,6 +50,7 @@ const propTypes = {
 
 class CSSTransitionGroupChild extends React.Component {
   static displayName = 'CSSTransitionGroupChild'
+  refNode = React.createRef()
 
   constructor(props) {
     super(props)
@@ -71,8 +71,12 @@ class CSSTransitionGroupChild extends React.Component {
     this.classNameAndNodeQueue.length = 0
   }
 
+  getNode() {
+    return this.refNode.current
+  }
+
   transition(animationType, finishCallback, timeout) {
-    const node = findDOMNode(this)
+    const node = this.getNode()
 
     if (!node) {
       if (finishCallback) {
@@ -181,7 +185,7 @@ class CSSTransitionGroupChild extends React.Component {
   }
 
   render() {
-    const props = { ...this.props }
+    const props = { ...this.props, ref: this.refNode }
     delete props.name
     delete props.appear
     delete props.enter


### PR DESCRIPTION
Similar to https://github.com/reactjs/react-transition-group/releases/tag/v4.4.0

This has a breaking change for functional components as they will need to use forwardRef