### PR TITLE
Avoid an occasional flicker when the exiting node is removed

### DIFF
--- a/packages/react-css-transition-replace/src/ReactCSSTransitionReplaceChild.js
+++ b/packages/react-css-transition-replace/src/ReactCSSTransitionReplaceChild.js
@@ -106,8 +106,15 @@ class CSSTransitionGroupChild extends React.Component {
         removeListeners()
       }
 
-      removeClass(node, className)
-      removeClass(node, activeClassName)
+      // If we're leaving, removing the classes can result in a redraw before
+      // React has chance to actually remove the node, which results in a flash
+      // of both nodes being displayed at the same time with their default styles
+      // (ie, probably 100% opacity).
+      // Since the node is about to be removed, we don't actually need to clean up the classes on it.
+      if (animationType !== "leave") {
+        removeClass(node, className)
+        removeClass(node, activeClassName)
+      }
 
       if (removeListeners) {
         removeListeners()


### PR DESCRIPTION
Fixes https://github.com/marnusw/react-css-transition-replace/issues/113

I struggled to come up with a good reproduction of the original bug - I hacked together this separate branch here: https://github.com/jdelStrother/react-css-transition-replace/commit/74dd9579b6b2a4e13f06c5b0fe67edcfb8317176

where you can see a flicker at 4.5 seconds here:
https://github.com/marnusw/react-css-transition-replace/assets/2377/2421d60f-4302-4eaa-a3a9-7d1ffac28ba8

I thought I might be able to trigger it more often by making the DOM tree heavier, but didn't have any luck with that. In my demo branch I get the flicker about once every 20 transitions. (In my production app it's more like every 2 or three transitions, but I've not been able to narrow down exactly why. Maybe just having more compositing layers on the page?)

